### PR TITLE
Initial version (WASM PoC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "verifier_tokyo"
+version = "0.1.0"
+authors = ["Sho Nakatani <example@example.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # verifier.tokyo
 Decode and verify Verifiable Credentials, like jwt.io
+
+## Implementation Details
+
+This project is a static web site that decodes and verifies Verifiable Credentials. The initial version fetches content from `https://example.com/` and displays it in a `<div>`.
+
+### Tools
+
+- Static web site
+  - GitHub Pages
+  - WASM
+
+- Core logics
+  - Rust
+  - Cargo
+
+- Frontend
+  - TypeScript
+  - HTML / CSS
+
+### Web design
+
+- Developer-friendly
+- Easy to maintain
+- Interactive (use Fetch API)
+
+## Usage Instructions
+
+### Prerequisites
+
+- Install [Rust](https://www.rust-lang.org/tools/install)
+- Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+
+### Building the Project
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/laysakura/verifier.tokyo.git
+   cd verifier.tokyo
+   ```
+
+2. Build the Rust project:
+   ```sh
+   wasm-pack build
+   ```
+
+3. Serve the static files (you can use any static file server, here we use `http-server`):
+   ```sh
+   npm install -g http-server
+   http-server
+   ```
+
+4. Open your browser and navigate to `http://localhost:8080` to see the site in action.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # verifier.tokyo
+
 Decode and verify Verifiable Credentials, like jwt.io
 
 ## Implementation Details
@@ -35,17 +36,20 @@ This project is a static web site that decodes and verifies Verifiable Credentia
 ### Building the Project
 
 1. Clone the repository:
+
    ```sh
    git clone https://github.com/laysakura/verifier.tokyo.git
    cd verifier.tokyo
    ```
 
 2. Build the Rust project:
+
    ```sh
    wasm-pack build
    ```
 
 3. Serve the static files (you can use any static file server, here we use `http-server`):
+
    ```sh
    npm install -g http-server
    http-server

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # verifier.tokyo
-
 Decode and verify Verifiable Credentials, like jwt.io
 
 ## Implementation Details
@@ -36,20 +35,17 @@ This project is a static web site that decodes and verifies Verifiable Credentia
 ### Building the Project
 
 1. Clone the repository:
-
    ```sh
    git clone https://github.com/laysakura/verifier.tokyo.git
    cd verifier.tokyo
    ```
 
 2. Build the Rust project:
-
    ```sh
    wasm-pack build
    ```
 
 3. Serve the static files (you can use any static file server, here we use `http-server`):
-
    ```sh
    npm install -g http-server
    http-server

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verifier Tokyo</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="content"></div>
+    <script src="main.ts"></script>
+</body>
+</html>

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,15 @@
+async function fetchContent() {
+    try {
+        const response = await fetch('https://example.com/');
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        const text = await response.text();
+        document.getElementById('content').innerText = text;
+    } catch (error) {
+        console.error('Fetch error:', error);
+        document.getElementById('content').innerText = 'Failed to load content';
+    }
+}
+
+fetchContent();

--- a/main.ts
+++ b/main.ts
@@ -1,11 +1,10 @@
+import init, { fetch_content, decode_and_verify_vc } from './pkg/verifier_tokyo';
+
 async function fetchContent() {
     try {
-        const response = await fetch('https://example.com/');
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
-        }
-        const text = await response.text();
-        document.getElementById('content').innerText = text;
+        await init();
+        const content = await fetch_content();
+        document.getElementById('content').innerText = content;
     } catch (error) {
         console.error('Fetch error:', error);
         document.getElementById('content').innerText = 'Failed to load content';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+use wasm_bindgen::prelude::*;
+
+// Function to be called from TypeScript
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello from Rust!".to_string()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,26 @@
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+use serde_json::Value;
+use reqwest::Client;
 
 // Function to be called from TypeScript
 #[wasm_bindgen]
-pub fn greet() -> String {
-    "Hello from Rust!".to_string()
+pub async fn fetch_content() -> Result<JsValue, JsValue> {
+    let client = Client::new();
+    let res = client.get("https://example.com/")
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let text = res.text()
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    Ok(JsValue::from_str(&text))
+}
+
+#[wasm_bindgen]
+pub fn decode_and_verify_vc(vc: &str) -> Result<JsValue, JsValue> {
+    let decoded: Value = serde_json::from_str(vc)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    // Here you would add your verification logic
+    Ok(JsValue::from_serde(&decoded).unwrap())
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,25 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+}
+
+#content {
+    max-width: 800px;
+    margin: 50px auto;
+    padding: 20px;
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+}
+
+h1 {
+    font-size: 24px;
+    color: #333;
+}
+
+p {
+    font-size: 16px;
+    color: #666;
+}


### PR DESCRIPTION
Related to #1

Add initial version of the static web site to decode and verify Verifiable Credentials.

* **HTML and CSS**:
  - Create `index.html` with a basic structure and a `<div>` to display fetched content.
  - Add `styles.css` with basic styles for the HTML elements.

* **TypeScript**:
  - Add `main.ts` to fetch content from `https://example.com/` and display it in the `<div>`.
  - Use the Fetch API and handle errors during the fetch operation.

* **Rust and WASM**:
  - Add `Cargo.toml` to define the Rust project and include dependencies for building a WASM project.
  - Add `src/lib.rs` with Rust code to compile to WASM and a function exposed to JavaScript using `wasm-bindgen`.

* **Documentation**:
  - Update `README.md` to include implementation details, tools used, web design principles, and usage instructions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/laysakura/verifier.tokyo/issues/1?shareId=a054952f-08ad-40c2-ba6e-111996d96ef9).